### PR TITLE
Remediate SourceClear Issues in vertx-base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <url>https://github.com/susom/vertx-base</url>
 
   <properties>
-    <vertx.version>3.4.2</vertx.version>
+    <vertx.version>3.5.3</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -160,6 +160,11 @@
       <artifactId>database-goodies</artifactId>
       <version>1.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.60</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This PR is fixing following vulnerabilities:

Vulnerability ID |  Vulnerability  | Library  | Version
----------------| -------------- | -------- | --------
CVE-2018-5382 | Hash Collision | Bouncy Castle Provider | 1.53
CVE-2017-7525 | Remote Code Execution (RCE) Through Deserialization | jackson-databind | 2.7.4
CVE-2017-15095 | Remote Code Execution (RCE) Through Deserialization | jackson-databind | 2.7.4
CVE-2017-17485 | Remote Code Execution (RCE) | jackson-databind | 2.7.4
CVE-2018-7489 | Remote Code Execution (RCE) | jackson-databind | 2.7.4

According to SouceClear, they do not have a confirmed fix for "CVE-2018-5382" yet. However, newer versions of the library have been released, and they suggest that we upgrade to 1.60, which is considered safe

The scan reports can be seen here:
https://susom.sourceclear.io/teams/3OOuY11/projects/90514/vulnerabilities?branch=master
