### PR TITLE
Upgraded vertx version to 3.6.0 and other dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>com.github.susom</groupId>
       <artifactId>database-goodies</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <url>https://github.com/susom/vertx-base</url>
 
   <properties>
-    <vertx.version>3.5.4</vertx.version>
+    <vertx.version>3.6.0</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>0.10.0</version>
+      <version>0.13.0</version>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>
@@ -143,7 +143,20 @@
           <groupId>org.apache.velocity</groupId>
           <artifactId>velocity</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.3</version>
     </dependency>
     <dependency>
       <!-- Transitive dependency of pac4j-saml that we need -->
@@ -179,7 +192,7 @@
     <dependency>
       <groupId>com.github.susom</groupId>
       <artifactId>database-goodies</artifactId>
-      <version>1.0</version>
+      <version>1.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/susom/vertx/base/CustomAuthenticator.java
+++ b/src/main/java/com/github/susom/vertx/base/CustomAuthenticator.java
@@ -43,7 +43,7 @@ public class CustomAuthenticator implements Security {
         log.warn("No authenticated user");
         rc.response().setStatusCode(401).end("401 Authentication Required");
       } else {
-        user.isAuthorised(authority, r -> {
+        user.isAuthorized(authority, r -> {
           if (r.succeeded() && r.result()) {
             rc.next();
           } else {

--- a/src/main/java/com/github/susom/vertx/base/FakeAuthenticator.java
+++ b/src/main/java/com/github/susom/vertx/base/FakeAuthenticator.java
@@ -311,7 +311,7 @@ public class FakeAuthenticator implements Security {
         log.warn("No authenticated user");
         rc.response().setStatusCode(401).end("401 Authentication Required");
       } else {
-        user.isAuthorised(authority, r -> {
+        user.isAuthorized(authority, r -> {
           if (r.succeeded() && r.result()) {
             rc.next();
           } else {

--- a/src/main/java/com/github/susom/vertx/base/OidcKeycloakAuthenticator.java
+++ b/src/main/java/com/github/susom/vertx/base/OidcKeycloakAuthenticator.java
@@ -334,7 +334,7 @@ public class OidcKeycloakAuthenticator implements Security {
         log.warn("No authenticated user");
         rc.response().setStatusCode(401).end("401 Authentication Required");
       } else {
-        user.isAuthorised(authority, r -> {
+        user.isAuthorized(authority, r -> {
           if (r.succeeded() && r.result()) {
             rc.next();
           } else {

--- a/src/main/java/com/github/susom/vertx/base/SamlAuthenticator.java
+++ b/src/main/java/com/github/susom/vertx/base/SamlAuthenticator.java
@@ -481,7 +481,7 @@ public class SamlAuthenticator implements Security {
         log.warn("No authenticated user");
         rc.response().setStatusCode(401).end("401 Authentication Required");
       } else {
-        user.isAuthorised(authority, r -> {
+        user.isAuthorized(authority, r -> {
           if (r.succeeded() && r.result()) {
             rc.next();
           } else {

--- a/src/test/java/com/github/susom/vertx/base/test/SampleMain.java
+++ b/src/test/java/com/github/susom/vertx/base/test/SampleMain.java
@@ -109,7 +109,7 @@ public class SampleMain {
         if (messageId == null) {
           rc.response().end(new JsonObject().put("message", "Hi").encode());
         } else {
-          AuthenticatedUser.required(rc).isAuthorised("service:secret:message:" + messageId, r -> {
+          AuthenticatedUser.required(rc).isAuthorized("service:secret:message:" + messageId, r -> {
             if (r.succeeded() && r.result()) {
               rc.response().end(new JsonObject().put("message", "Hi " + messageId).encode());
             } else {
@@ -133,7 +133,7 @@ public class SampleMain {
       new DatabaseHealthCheck(vertx, db, config).addStatusHandlers(root);
 
       // Start the server
-      vertx.createHttpServer().requestHandler(root::accept).listen(8888, "localhost", h -> {
+      vertx.createHttpServer().requestHandler(root).listen(8888, "localhost", h -> {
         if (h.succeeded()) {
           int port = h.result().actualPort();
           log.info("Started server on port " + port + ":\n    http://localhost:" + port + "/app" );


### PR DESCRIPTION
@garricko 

This PR contains the following dependency updates.

- vertx version upgrade from 3.5.4 to 3.6.0, Because of the version upgrade we have done minor updates in the source code.
- google-auth-library-oauth2-http
- httpclient

We built the project using .travis.yml and it was successful.

Please find the following build logs links.

- vertx-base: https://docs.google.com/document/d/1vpRzmtRpI2gSwso6BRASd7TeMvfvPkjywRogJP_KXzE/edit

- vertx-parent:
https://docs.google.com/document/d/1Dl0gmegr_gtcXERLfPTxJjwc1nJC56y61Rh1I6R6OgE/edit

- vertx-template:
https://docs.google.com/document/d/1cx-TPJJwJfNwTUjWPsvPYR-N4boU9kxIbJzbEP2HpGM/edit
https://docs.google.com/document/d/1ybSfXrDrXmF-adKaOrTSrKXCh7u-RwtIln3C_B_aBuE/edit
https://docs.google.com/document/d/1mGcbuw-qQ6uyDXR7D57oD24OUgPIIErXSn-VgsBWxwU/edit

With the above updates, the source clear risk score is reduced from 28 to 0.

Please review the PR and let us know your feedback.


