### PR TITLE
Do nothing if there is no body to read

### DIFF
--- a/src/main/java/com/github/susom/vertx/base/StrictBodyHandler.java
+++ b/src/main/java/com/github/susom/vertx/base/StrictBodyHandler.java
@@ -66,6 +66,11 @@ public class StrictBodyHandler implements Handler<RoutingContext> {
   }
 
   public void handle(RoutingContext rc) {
+    if (rc.request().isEnded()) {
+      rc.next();
+      return;
+    }
+
     if (multipart) {
       rc.request().setExpectMultipart(true);
     }


### PR DESCRIPTION
This seems to make things work for body-less GETs.