### PR TITLE
CHOIR-4664: WHW Empowered Relief new link email handling special case

### DIFF
--- a/sample.properties
+++ b/sample.properties
@@ -1,3 +1,4 @@
 mailgun.domain=example.com
 mailgun.api.key=...
 mailgun.from=you@example.com
+mailgun.reply.to= <optional alternate email reply-to>

--- a/src/main/java/com/github/susom/vertx/base/EmailLoginAuthenticator.java
+++ b/src/main/java/com/github/susom/vertx/base/EmailLoginAuthenticator.java
@@ -50,6 +50,21 @@ import static io.vertx.core.http.HttpHeaders.SET_COOKIE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class EmailLoginAuthenticator implements Security {
+  public final static String FOOTER_TEXT = "email.message.footer.text";
+  public final static String FOOTER_HTML = "email.message.footer.html";
+
+  public final static String HEADER_TEXT = "email.message.header.text";
+  public final static String HEADER_HTML = "email.message.header.html";
+
+  public final static String MAILGUN_API_KEY = "mailgun.api.key";
+  public final static String MAILGUN_DOMAIN = "mailgun.domain";
+  public final static String MAILGUN_FROM = "mailgun.from";
+  public final static String MAILGUN_HOST = "mailgun.host";
+  public final static String MAILGUN_HTML = "mailgun.html";
+  public final static String MAILGUN_REPLY_TO = "mailgun.reply.to";
+  public final static String MAILGUN_SUBJECT = "mailgun.subject";
+  public final static String MAILGUN_TEXT = "mailgun.text";
+
   private static final Logger log = LoggerFactory.getLogger(EmailLoginAuthenticator.class);
   private final Vertx vertx;
   private final Router root;
@@ -63,6 +78,7 @@ public class EmailLoginAuthenticator implements Security {
   private final String mailgunDomain;
   private final String mailgunApiKey;
   private final String mailgunFrom;
+  private final String mailgunReplyTo;
 
   public EmailLoginAuthenticator(Vertx vertx, Router root, SecureRandom random, EmailLoginValidator validator, Function<String, String> cfg) throws IOException {
     this.vertx = vertx;
@@ -71,13 +87,13 @@ public class EmailLoginAuthenticator implements Security {
     this.validator = validator;
     this.config = Config.from().custom(cfg).get();
 
-    String footerText = config.getString("email.message.footer.text");
+    String footerText = config.getString(FOOTER_TEXT);
     footerText = footerText == null ? "" : footerText;
-    String footerHtml = config.getString("email.message.footer.html");
+    String footerHtml = config.getString(FOOTER_HTML);
     footerHtml = footerHtml == null ? "" : footerHtml;
-    String headerText = config.getString("email.message.header.text");
+    String headerText = config.getString(HEADER_TEXT);
     headerText = headerText == null ? "" : headerText;
-    String headerHtml = config.getString("email.message.header.html");
+    String headerHtml = config.getString(HEADER_HTML);
     headerHtml = headerHtml == null ? "" : headerHtml;
     if (headerText.isEmpty() && headerHtml.isEmpty()) {
       headerText = "Enter your email address to access this site.";
@@ -110,10 +126,11 @@ public class EmailLoginAuthenticator implements Security {
 
     httpClient = vertx.createHttpClient(new HttpClientOptions().setSsl(true));
 
-    mailgunHost = config.getString("mailgun.host", "api.mailgun.net");
-    mailgunDomain = config.getString("mailgun.domain");
-    mailgunApiKey = config.getString("mailgun.api.key");
-    mailgunFrom = config.getString("mailgun.from");
+    mailgunHost = config.getString(MAILGUN_HOST, "api.mailgun.net");
+    mailgunDomain = config.getString(MAILGUN_DOMAIN);
+    mailgunApiKey = config.getString(MAILGUN_API_KEY);
+    mailgunFrom = config.getString(MAILGUN_FROM);
+    mailgunReplyTo = config.getString(MAILGUN_REPLY_TO);
 
     if (mailgunDomain == null || mailgunApiKey == null || mailgunFrom == null) {
       log.warn("Config mailgun.domain, mailgun.api.key, or mailgun.from is not set so we will log emails instead of sending");
@@ -353,9 +370,12 @@ public class EmailLoginAuthenticator implements Security {
           QueryStringEncoder enc = new QueryStringEncoder("");
           enc.addParam("from", mailgunFrom);
           enc.addParam("to", email);
-          enc.addParam("subject", config.getString("mailgun.subject", "The login link you requested"));
-          String text = config.getString("mailgun.text");
-          String html = config.getString("mailgun.html");
+          if (mailgunReplyTo != null) {
+            enc.addParam("h:Reply-To", mailgunReplyTo);
+          }
+          enc.addParam("subject", config.getString(MAILGUN_SUBJECT, "The login link you requested"));
+          String text = config.getString(MAILGUN_TEXT);
+          String html = config.getString(MAILGUN_HTML);
           if (text == null && html == null) {
             text = "Here is the login link you requested:\n\n[LINK]\n\nDo not forward or share with anyone.";
           }

--- a/src/test/java/com/github/susom/vertx/base/test/EmailLoginSample.java
+++ b/src/test/java/com/github/susom/vertx/base/test/EmailLoginSample.java
@@ -35,6 +35,10 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.susom.vertx.base.EmailLoginAuthenticator.MAILGUN_HTML;
+import static com.github.susom.vertx.base.EmailLoginAuthenticator.MAILGUN_SUBJECT;
+import static com.github.susom.vertx.base.EmailLoginAuthenticator.MAILGUN_TEXT;
+
 import static com.github.susom.vertx.base.VertxBase.*;
 
 /**
@@ -66,9 +70,9 @@ public class EmailLoginSample {
 //          .value("email.message.footer.text", "Be sure you put in the email you signed up with.")
 //          .value("email.message.footer.html", "Be sure you <b>put in the email</b> you signed up with.")
 //          .value("email.message.instructions", "Check your email.")
-          .value("mailgun.subject", "Custom subject")
-          .value("mailgun.text", "Here is the link:\n\n[LINK]")
-          .value("mailgun.html", "<html><body><p>Here is the link:</p><p><a href='[LINK]'>Login</a></p></body></html>")
+          .value(MAILGUN_SUBJECT, "Custom subject")
+          .value(MAILGUN_TEXT, "Here is the link:\n\n[LINK]")
+          .value(MAILGUN_HTML, "<html><body><p>Here is the link:</p><p><a href='[LINK]'>Login</a></p></body></html>")
           // In local.properties set mailgun.domain, mailgun.api.key, and mailgun.from
           .propertyFile("local.properties").get();
 


### PR DESCRIPTION
Needed to ensure any WHW login link emails replies get sent to whw-workersinjuryandillness@stanfordhealthcare.org as they require. 

I am sending the emails from MyEmpoweredRelief@med.stanford.edu to give something familiar (will review with them) and get past mailgun, but need to be sure all WHW traffic goes to their email.  This small change enables that. 